### PR TITLE
enable index.html as default [SBK-183]

### DIFF
--- a/faucet/app.py
+++ b/faucet/app.py
@@ -71,7 +71,7 @@ async def ape_exception_handler(request: Request, exc: ApeException):
 
 
 # NOTE: must come after any routes, to ensure the fallthrough works properly
-app.mount("/", StaticFiles(directory=(Path(__file__).parent / "web")), name="app")
+app.mount("/", StaticFiles(directory=(Path(__file__).parent / "web"), html=True), name="app")
 
 
 def start():


### PR DESCRIPTION
Without this, open `http://127.0.0.1:8000/` will see `{"detail":"Not Found"}`, and one will have to open `http://127.0.0.1:8000/index.html` explicitly to see the proper page.

![Xnip2023-07-22_17-06-26](https://github.com/ApeWorX/faucet/assets/189283/3de145ea-aa33-404c-942f-3075837f9ef2)
